### PR TITLE
Added scraper for game title and nsuid.

### DIFF
--- a/connect/connect.go
+++ b/connect/connect.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/davidclarafigueiredo/SaleNotifier/scraper"
 	"github.com/rs/zerolog/log"
 )
 
 func Connect() []byte {
 	// Get the URL from the environment variable
-	url := os.Getenv("REQUEST")
+	url := os.Getenv("REQUEST") + scraper.GetNSUID()
 	// Connect to the site
 	res, err := http.Get(url)
 	if err != nil {

--- a/data/import
+++ b/data/import
@@ -1,0 +1,2 @@
+https://www.nintendo.com/de-de/Spiele/Nintendo-Switch-Download-Software/Disney-Dreamlight-Valley-2232608.html
+https://www.nintendo.com/de-de/Spiele/Nintendo-Switch-Download-Software/No-Man-s-Sky-2169216.html

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/davidclarafigueiredo/SaleNotifier/scraper"
 	"github.com/rs/zerolog/log"
 )
 
@@ -55,7 +56,7 @@ func unmarshal(body []byte) bool {
 
 func GetPrice(body []byte) string {
 	if unmarshal(body) {
-		game = prodcut{Title: "Title", Price: 0}
+		game = prodcut{Title: scraper.GetGameTitle(), Price: 0}
 		fmt.Printf("Title: %s\n", game.Title)
 		return jsonbody.Prices[0].DiscountPrice.Amount
 	}

--- a/main.go
+++ b/main.go
@@ -6,10 +6,13 @@ import (
 	"github.com/davidclarafigueiredo/SaleNotifier/config"
 	"github.com/davidclarafigueiredo/SaleNotifier/connect"
 	"github.com/davidclarafigueiredo/SaleNotifier/handler"
+	"github.com/davidclarafigueiredo/SaleNotifier/scraper"
 )
 
 func main() {
 	config.Init()
 	fmt.Printf("%s\n", handler.GetPrice(connect.Connect()))
 	//handler.SendMail()
+	fmt.Printf("Game Title: %s\n", scraper.GetGameTitle())
+	fmt.Printf("NSUID: %s\n", scraper.GetNSUID())
 }

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -1,0 +1,68 @@
+package scraper
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+)
+
+func GetURL() string {
+	file, err := os.Open("data/import")
+	if err != nil {
+		fmt.Println("Error opening file:", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	if scanner.Scan() { // Reads the first line
+		return scanner.Text()
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Println("Error reading file:", err)
+	}
+	return ""
+}
+
+func GetInfo(info string) string {
+	url := GetURL()
+	if url == "" {
+		log.Fatal("No URL found in wishlist.txt")
+	}
+
+	// Send HTTP request
+	response, err := http.Get(url)
+	if err != nil {
+		log.Fatal("Error fetching the webpage:", err)
+	}
+	defer response.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Fatal("Error reading response body:", err)
+	}
+
+	titleRegex := regexp.MustCompile(`"` + info + `"\s*:\s*"([^"]+)"`)
+	matches := titleRegex.FindStringSubmatch(string(body))
+
+	if len(matches) > 1 {
+		return matches[1]
+	}
+
+	fmt.Printf("%s not found.\n", info)
+	return ""
+}
+
+func GetNSUID() string {
+	return GetInfo("offdeviceNsuID")
+}
+
+func GetGameTitle() string {
+	return GetInfo("gameTitle")
+}


### PR DESCRIPTION
NSUID and game title can now be scraped from the eShop Page of a specific game, given the url of this page. The NSUID is now used to complete the url for the api request. The local .env has to be adapted, for this just delete the NSUID at the end of REQUEST. This is automatically completed with the scraped NSUID.